### PR TITLE
fix build process by adding gulp-uglify dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-postcss": "^7.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-terser": "^1.1.6",
+    "gulp-uglify": "^3.0.1",
     "gulp-zip": "^4.1.0",
     "lost": "^8.2.0",
     "postcss-cssnext": "^3.0.2",


### PR DESCRIPTION
This fixes the following error when running `npm run start`:

```
Error: Cannot find module 'gulp-uglify'
    at Function.Module._resolveFilename (module.js:548:15)
    at Function.Module._load (module.js:475:25)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/Users/tuomassalo/dev/glightbox/gulpfile.js:20:16)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```