### PR TITLE
Prevent exceding `this.elements.length` in preloadSlide

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1641,7 +1641,7 @@ class GlightboxInit {
     preloadSlide(index) {
         // Verify slide index, it can not be lower than 0
         // and it can not be greater than the total elements
-        if (index < 0 || index > this.elements.length)
+        if (index < 0 || index > this.elements.length - 1)
             return false
 
         if (utils.isNil(this.elements[index]))


### PR DESCRIPTION
Similar issue to #106. Thanks for the merge!

I didn't update `dist/` because it still seems like I have different versions of packages generating different output. Maybe some of the versions aren't pinned?