### PR TITLE
Fix openAt(0) to not fallback to this.settings.startAt

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1510,7 +1510,7 @@ class GlightboxInit {
         this.activeSlide = null
         this.prevActiveSlideIndex = null
         this.prevActiveSlide = null
-        let index = (startAt ? startAt : this.settings.startAt)
+        let index = (utils.isNumber(startAt) ? startAt : this.settings.startAt)
 
         if (element && utils.isNil(index)) { // if element passed and startAt is null, get the index
             index = this.elements.indexOf(element)


### PR DESCRIPTION
`0` is falsy so `this.settings.startAt` was used instead.

Pseudo code with the problem:
```js
var lb = GLightbox({
  startAt: 2,
});
lb.openAt(0);
```