### PR TITLE
Make js in src/ a valid ES module without compiling

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -4,8 +4,8 @@
  * made by https://www.biati.digital
  */
 
-import TouchEvents from './touch-events';
-import ZoomImages from './zoom';
+import TouchEvents from './touch-events.js';
+import ZoomImages from './zoom.js';
 
 const isMobile = navigator.userAgent.match(/(iPad)|(iPhone)|(iPod)|(Android)|(PlayBook)|(BB10)|(BlackBerry)|(Opera Mini)|(IEMobile)|(webOS)|(MeeGo)/i);
 const isTouch = isMobile !== null || document.createTouch !== undefined || ('ontouchstart' in window) || ('onmsgesturechange' in window) || navigator.msMaxTouchPoints;


### PR DESCRIPTION
This makes development easier as you don't even need to use `npm` until you are ready to update dist/

The compilation still seems to work fine for me with the file suffix added so I don't see any downside to this.