### PR TITLE
remove thrown error if no glightbox-element exists on page

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -2072,10 +2072,12 @@ class GlightboxInit {
         nodes = Array.prototype.slice.call(nodes);
 
         each(nodes, (el, i) => {
-            const elData = getSlideData(el, this.settings);
-            elData.node = el;
-            elData.index = i;
-            list.push(elData);
+            if (el.length != 0) {
+                const elData = getSlideData(el, this.settings);
+                elData.node = el;
+                elData.index = i;
+                list.push(elData);
+            }
         })
 
         return list;


### PR DESCRIPTION
this error will be fixed if no usable element is found
`glightbox.min.js:1 Uncaught TypeError: t.getAttribute is not a function
    at B (glightbox.min.js:1)
    at Array.<anonymous> (glightbox.min.js:1)
    at T (glightbox.min.js:1)
    at t.value (glightbox.min.js:1)
    at t.value (glightbox.min.js:1)
    at ../node_modules/glightbox/dist/js/glightbox.min.js (glightbox.min.js:1)
    at Module../js/app.js (app.js:10)
    at __webpack_require__ (bootstrap:19)
    at bootstrap:83
    at bootstrap:83`