### PR TITLE
Glightbox.getElements(): use Array.prototype.forEach() instead of eac…

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -2071,7 +2071,7 @@ class GlightboxInit {
         }
         nodes = Array.prototype.slice.call(nodes);
 
-        each(nodes, (el, i) => {
+        nodes.forEach((el, i) => {
             const elData = getSlideData(el, this.settings);
             elData.node = el;
             elData.index = i;


### PR DESCRIPTION
The following code throws an exception because the `nodes` variables is iterated upon by `each()` even if it has no elements. The exception is thrown by `getSlideData()` at `glightbox.js:561` because `element` is an empty array. 
```
const lightbox = GLightbox({
    selector: null
});
```