### PR TITLE
📝 Updates documentation surrounding importing as a module 

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ bower install glightbox
 ```
 
 ```javascript
-import GLightbox from 'glightbox';
+import 'glightbox';
 ```
 
 Or manually download and link `glightbox.min.js` in your HTML:

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ OR CDN
 <script type="text/javascript">
   const lightbox = GLightbox({ ...options });
 </script>
+
+OR USING ES MODULES 
+
+<script type="module">
+  import 'https://cdn.jsdelivr.net/gh/mcstudios/glightbox/dist/js/glightbox.min.js';
+
+  const lightbox = GLightbox({ ...options });
+</script>
 ```
 
 ## Examples


### PR DESCRIPTION
Related issue: #212 

Current documentation suggests importing as:

```js
import GLightbox from 'glightbox';
```

Since GLightbox currently has a `UMD` wrapper (or `UMD`-like), there is no `export default` statement.
The solution to this is to just import the `glightbox.min.js` file.

Using [this](https://gomakethings.com/side-effects-in-es-modules-with-vanilla-js/) article as a guide,
I removed the `GLightbox from` on the `import`.

Importing just the JS file will import the `UMD` wrapper as a "side-effect".
Then GLightbox becomes available just as if it was a separate script tag.

Also adds an example for `<script type="module">`, since that had come up as a debugging example in the related issue.