### PR TITLE
Adds missing 'px' to max-width of video description

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1135,7 +1135,7 @@ class GlightboxInit {
             } else {
                 video.parentNode.style.maxWidth = `${maxWidth}`;
                 if (descriptionResize) {
-                    description.setAttribute('style', `max-width: ${maxWidth};`);
+                    description.setAttribute('style', `max-width: ${maxWidth}px;`);
                 }
             }
         }


### PR DESCRIPTION
Setting the max-width on the style attribute of the video description was missing the `px` unit so video video descriptions ended up with a unit-less max-width, breaking the layout. This just pops the `px` onto that call on line 1138. Tested and working on Chrome, Firefox, and Safari but did not test in IE, though it's a convention used elsewhere in the code and a pretty simple matter, so I feel pretty confident it will pass in IE11.