### PR TITLE
Fix a JS error when the description attribute is an invalid selector …

### DIFF
--- a/src/js/core/slide-parser.js
+++ b/src/js/core/slide-parser.js
@@ -143,9 +143,25 @@ export default class SlideConfigParser {
             }
         }
 
-        if (data.description && data.description.substring(0, 1) == '.' && document.querySelector(data.description)) {
-            data.description = document.querySelector(data.description).innerHTML;
-        } else {
+        // Try to get the description from a referenced element
+        if (data.description && data.description.substring(0, 1) === '.') {
+            let description;
+
+            try {
+                description = document.querySelector(data.description).innerHTML;
+            } catch (error) {
+                if (!(error instanceof DOMException)) {
+                    throw error;
+                }
+            }
+
+            if (description) {
+                data.description = description;
+            }
+        }
+
+        // Try to get the description from a .glightbox-desc element
+        if (!data.description) {
             let nodeDesc = element.querySelector('.glightbox-desc');
             if (nodeDesc) {
                 data.description = nodeDesc.innerHTML;


### PR DESCRIPTION
…but stars with a dot, e.g., "... lorem ipsum".

Sample HTML:

```html
<a href="files/media/alt/gutebeispiele/8_02-2.jpg" data-lightbox="lb14954" data-description="...und mit Klappschott als Schutz">…</a>
```

We get this JS error in the console:

```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '...und mit Klappschott als Schutz' is not a valid selector.
```

Note that this will throw an error if element does not exist (e.g., `data-description=".non-existing-element"`), but I think it's better to report it right away than silently ignore it.