### PR TITLE
Fix opening glightbox inside another glightbox

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1230,8 +1230,11 @@ class GlightboxInit {
             }
 
             const body = document.body;
-            _.removeClass(html, 'glightbox-open');
-            _.removeClass(body, 'glightbox-open touching gdesc-open glightbox-touch glightbox-mobile gscrollbar-fixer');
+            const onlyOneGLightbox = document.querySelectorAll('#glightbox-body').length <= 1;
+            if (onlyOneGLightbox) {
+                _.removeClass(html, 'glightbox-open');
+                _.removeClass(body, 'glightbox-open touching gdesc-open glightbox-touch glightbox-mobile gscrollbar-fixer');
+            }
             this.modal.parentNode.removeChild(this.modal);
 
             this.trigger('close');
@@ -1241,10 +1244,13 @@ class GlightboxInit {
                 this.settings.onClose();
             }
 
-            const styles = document.querySelector('.gcss-styles');
-            if (styles) {
-                styles.parentNode.removeChild(styles);
+            if (onlyOneGLightbox) {
+                const styles = document.querySelector('.gcss-styles');
+                if (styles) {
+                    styles.parentNode.removeChild(styles);
+                }
             }
+
             this.lightboxOpen = false;
             this.closing = null;
         });

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -956,14 +956,14 @@ class GlightboxInit {
         lightboxHTML = _.createHTML(lightboxHTML);
         document.body.appendChild(lightboxHTML);
 
-        const modal = document.getElementById('glightbox-body');
+        const modal = document.body.lastElementChild;
         this.modal = modal;
         let closeButton = modal.querySelector('.gclose');
         this.prevButton = modal.querySelector('.gprev');
         this.nextButton = modal.querySelector('.gnext');
         this.overlay = modal.querySelector('.goverlay');
         this.loader = modal.querySelector('.gloader');
-        this.slidesContainer = document.getElementById('glightbox-slider');
+        this.slidesContainer = modal.querySelctor('.gslider');
         this.bodyHiddenChildElms = bodyChildElms;
         this.events = {};
 


### PR DESCRIPTION
There is currently a bug when a glightbox is opened inside another one then it will be stuck on a infinite loading loop.
This is caused by the ```getElementById``` selector which won't work with multiple IDs.

This will basically fix this issue https://github.com/biati-digital/glightbox/issues/262

This will select the last child of the body element which is the glightbox as it was appended as a child to the body.

I couldn't test it cross browser.