### PR TITLE
Add default white background for transparent images

### DIFF
--- a/src/postcss/glightbox.css
+++ b/src/postcss/glightbox.css
@@ -153,6 +153,7 @@
         touch-action: none;
         margin: auto;
         min-width: 200px;
+        background-color: white;
 
         @media (--medium-small-viewport) {
             max-height: 97vh;


### PR DESCRIPTION
Transparent PNGs look broken with the dark lightbox backdrop "shining through":

<img width="1131" alt="Screen Shot 2021-08-20 at 11 51 07 AM" src="https://user-images.githubusercontent.com/306708/130215478-ed1db413-f37c-4468-a9ec-a7f1fe227e1f.png">

This adds a white default background to the `img` on the slide:

<img width="1130" alt="Screen Shot 2021-08-20 at 11 51 55 AM" src="https://user-images.githubusercontent.com/306708/130215592-d3183e4f-0268-4d67-a463-bde5c0d54add.png">

Thoughts:

This assumes `#fff` makes a good default background color for transparent images which may or may not be a safe assumption. Maybe it'd be better to make this user configurable without CSS modifications?

Also, if anybody needs a copy-pasteable CSS snippet to implement this change without modifying `glightbox.css`, you can use this:

```css
/* Add default white background for transparent images */
.gslide-image img {
  background-color: white;
}
```