### PR TITLE
Fix #282: Close Button unreachable via keyboard navigation on last slide

### DIFF
--- a/src/js/core/keyboard-navigation.js
+++ b/src/js/core/keyboard-navigation.js
@@ -21,15 +21,17 @@ function getNextFocusElement(current = -1) {
         current = parseInt(current);
     }
 
-    let newIndex = current < 0 ? 1 : current + 1;
-    if (newIndex > btns.length) {
-        newIndex = '1';
-    }
-
     const orders = [];
     each(btns, (btn) => {
         orders.push(btn.getAttribute('data-taborder'));
     });
+    const highestOrder = Math.max.apply(Math, orders.map((order) => parseInt(order)));
+
+    let newIndex = current < 0 ? 1 : current + 1;
+    if (newIndex > highestOrder) {
+        newIndex = '1';
+    }
+
     const nextOrders = orders.filter((el) => el >= parseInt(newIndex));
     const nextFocus = nextOrders.sort()[0];
 


### PR DESCRIPTION
This is a fix for #282 which makes the Close-Button on the last slide of a slideshow reachable via keyboard controls. 

I pretty much just added a line to calculate the highest data-taborder. This is then used to check, if the nextIndex should be reset to '1' again or not. 

For further information see #282.

Tested in FF and Chrome.