### PR TITLE
Remove iframe onload listener after it initialised

### DIFF
--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -354,6 +354,8 @@ export function createIframe(config) {
         if (isFunction(callback)) {
             callback();
         }
+
+        iframe.onload = null;
     };
 
     if (appendTo) {

--- a/src/js/utils/helpers.js
+++ b/src/js/utils/helpers.js
@@ -350,12 +350,11 @@ export function createIframe(config) {
         iframe.setAttribute('allow', allow);
     }
     iframe.onload = function() {
+        iframe.onload = null;
         addClass(iframe, 'node-ready');
         if (isFunction(callback)) {
             callback();
         }
-
-        iframe.onload = null;
     };
 
     if (appendTo) {


### PR DESCRIPTION
Remove iframe onload listener after it initialized.

This is need because when ifraime contain embed page, it will trigger onload event every time User do "in-frame" navigtion.
That, example, will trigger "open animation" every time when the iframe reloaded.