### PR TITLE
[BUGFIX] Don't set any font-family

### DIFF
--- a/src/postcss/glightbox.css
+++ b/src/postcss/glightbox.css
@@ -524,7 +524,6 @@ iframe.wait-autoplay {
     .gslide-title {
         font-size: 1em;
         font-weight: normal;
-        font-family: arial;
         color: #000;
         margin-bottom: 19px;
         line-height: 1.4em;
@@ -533,7 +532,6 @@ iframe.wait-autoplay {
     .gslide-desc {
         font-size: 0.86em;
         margin-bottom: 0;
-        font-family: arial;
         line-height: 1.4em;
     }
 


### PR DESCRIPTION
**Overview:**
This pull requests removes all font-family properties from the CSS.

**Reasoning:**
Setting a font-family for some classes leads to mixed font selections on the page.
In my opinion, the default font of the website should be used, not a font provided by the library.