### PR TITLE
perf(glightbox): Fixes potential memory leak with IntersectionObserver

### DIFF
--- a/packages/glightbox/src/glightbox.ts
+++ b/packages/glightbox/src/glightbox.ts
@@ -15,6 +15,7 @@ export default class GLightbox {
     nextButton: HTMLButtonElement | null = null;
     overlay: HTMLButtonElement | null = null;
     slidesContainer: HTMLElement | null = null;
+    observer: IntersectionObserver;
 
     constructor(options: Partial<GLightboxOptions> = {}) {
         this.options = mergeObjects(GLightboxDefaults, options);
@@ -288,7 +289,7 @@ export default class GLightbox {
 
         this.processVariables(this.modal);
 
-        const observer = new IntersectionObserver((entries) => {
+        this.observer = new IntersectionObserver((entries) => {
             entries.forEach((entry) => {
                 removeClass(entry.target, 'visible');
                 if (entry.isIntersecting && this.state.get('open')) {
@@ -333,7 +334,7 @@ export default class GLightbox {
                 this.slidesContainer?.insertAdjacentHTML('beforeend', slideHTML);
                 const created = this.slidesContainer?.querySelectorAll('.gl-slide')[index];
                 if (created) {
-                    observer.observe(created);
+                    this.observer.observe(created);
                 }
                 index++;
             }
@@ -399,6 +400,7 @@ export default class GLightbox {
     public destroy(): void {
         this.close();
         this.clearAllEvents(true);
+        this.observer.disconnect();
     }
 
     public reload(): void {

--- a/packages/glightbox/src/glightbox.ts
+++ b/packages/glightbox/src/glightbox.ts
@@ -15,7 +15,7 @@ export default class GLightbox {
     nextButton: HTMLButtonElement | null = null;
     overlay: HTMLButtonElement | null = null;
     slidesContainer: HTMLElement | null = null;
-    observer: IntersectionObserver;
+    private observer: IntersectionObserver;
 
     constructor(options: Partial<GLightboxOptions> = {}) {
         this.options = mergeObjects(GLightboxDefaults, options);


### PR DESCRIPTION
The build method creates an IntersectionObserver, but it is not cleaned up at any point. This means that each time an instance is opened, a new IO is created with all the previous looking for elements that no longer exist to intersect with the viewport. To prevent this, I saved the observer to the GLightbox class so it could be cleaned up using `.disconnect()` in the destroy method.

```ts
class GLightbox {
  private observer: IntersectionObserver;
  build() {
    // ...
    this.observer = new IntersectionObserver();
    // ...
  }

  destroy() {
    // ...
    this.observer.disconnect()
  }
}
```