### PR TITLE
fix(glightbox.js): remove background focus, fix issue #555

### DIFF
--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -181,6 +181,11 @@ class GlightboxInit {
             index = 0;
         }
 
+        const activeElement = document.activeElement;
+        if (activeElement) {
+          activeElement.blur();
+        }
+
         this.build();
 
         _.animateElement(this.overlay, this.settings.openEffect === 'none' ? 'none' : this.settings.cssEfects.fade.in);


### PR DESCRIPTION
Fixes issue #555: To fix "Blocked aria-hidden on an element because its descendant retained focus..." error on chrome. The issue is the original thumbnail retaining focus despite being aria-hidden, once modal opens.

Drawback is the original focus position is lost. Therefore there is a better solution to store original focus position and restore it when modal is closing.

Not tested in IE, but sure OK.