### PR TITLE
feat: add customizable aria-labels for navigation buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ myGallery.setElements([...]);
 | moreText | string | `See more` | More text for descriptions on mobile devices. |
 | moreLength | number | `60` | Number of characters to display on the description before adding the moreText link (only for mobiles), if 0 it will display the entire description. |
 | closeButton | boolean | `true` | Show or hide the close button. |
+| closeButtonText | string  | `Close` | Text for the close button. | 
+| nextButtonText | string  | `Next` | Text for the next slide button. |
+| prevButtonText | string  | `Previous` | Text for the previous slide button. |
 | touchNavigation | boolean | `true` | Enable or disable the touch navigation (swipe). |
 | touchFollowAxis | boolean | `true` | Image follow axis when dragging on mobile. |
 | keyboardNavigation | boolean | `true` | Enable or disable the keyboard navigation. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -142,6 +142,24 @@ declare namespace Glightbox {
          */
         closeButton?: boolean;
         /**
+         * Text for the close button.
+         *
+         * @default 'Close'
+         */
+        closeButtonText?: string;
+        /**
+         * Text for the next slide button.
+         *
+         * @default 'Next'
+         */
+        nextButtonText?: string;
+        /**
+         * Text for the previous slide button.
+         *
+         * @default 'Previous'
+         */
+        prevButtonText?: string;
+        /**
          * Enable or disable the touch navigation (swipe).
          * 
          * @default true

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -116,9 +116,9 @@ defaults.lightboxHTML = `<div id="glightbox-body" class="glightbox-container" ta
     <div class="goverlay"></div>
     <div class="gcontainer">
     <div id="glightbox-slider" class="gslider"></div>
-    <button class="gclose gbtn" aria-label="Close" data-taborder="3">{closeSVG}</button>
-    <button class="gprev gbtn" aria-label="Previous" data-taborder="2">{prevSVG}</button>
-    <button class="gnext gbtn" aria-label="Next" data-taborder="1">{nextSVG}</button>
+    <button class="gclose gbtn" aria-label="{closeButtonText}" data-taborder="3">{closeSVG}</button>
+    <button class="gprev gbtn" aria-label="{prevButtonText}" data-taborder="2">{prevSVG}</button>
+    <button class="gnext gbtn" aria-label="{nextButtonText}" data-taborder="1">{nextSVG}</button>
 </div>
 </div>`;
 
@@ -954,11 +954,17 @@ class GlightboxInit {
         const nextSVG = _.has(this.settings.svg, 'next') ? this.settings.svg.next : '';
         const prevSVG = _.has(this.settings.svg, 'prev') ? this.settings.svg.prev : '';
         const closeSVG = _.has(this.settings.svg, 'close') ? this.settings.svg.close : '';
+        const closeButtonText = this.settings.closeButtonText ?? 'Close';
+        const prevButtonText = this.settings.prevButtonText ?? 'Previous';
+        const nextButtonText = this.settings.nextButtonText ?? 'Next';
 
         let lightboxHTML = this.settings.lightboxHTML;
         lightboxHTML = lightboxHTML.replace(/{nextSVG}/g, nextSVG);
         lightboxHTML = lightboxHTML.replace(/{prevSVG}/g, prevSVG);
         lightboxHTML = lightboxHTML.replace(/{closeSVG}/g, closeSVG);
+        lightboxHTML = lightboxHTML.replace(/{closeButtonText}/g, closeButtonText);
+        lightboxHTML = lightboxHTML.replace(/{prevButtonText}/g, prevButtonText);
+        lightboxHTML = lightboxHTML.replace(/{nextButtonText}/g, nextButtonText);
 
         lightboxHTML = _.createHTML(lightboxHTML);
         document.body.appendChild(lightboxHTML);


### PR DESCRIPTION
Resolves #566 

This adds support for customizing the ARIA labels of the prev, next and close buttons:
```js
const lightbox = GLightbox({
                closeButtonText: 'customClose',
                nextButtonText: 'customNext',
                prevButtonText: 'customPrevious'
            });
```

If they are not set, they fallback to their current values.

