### PR TITLE
Fix "elements" type to accept array instead of only an empty tuple (or null)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ declare namespace Glightbox {
          * 
          * @default null
          */
-        elements?: [] | null;
+        elements?: any[] | null;
         /**
          * Name of the skin, it will add a class to the lightbox
          * so you can style it with css.
@@ -566,3 +566,4 @@ declare function GLightbox(options: Glightbox.Options): InstanceType<typeof Glig
 
 export = GLightbox;
 export as namespace GLightbox;
+


### PR DESCRIPTION
Hi, 👋 

I've encountered an issue when assigning an array of elements to the `GLightbox.Options`: 

```typescript
TS2322: Type ImageObject[] is not assignable to type []
  Target allows only 0 element(s) but source may have more.
```

The cause is that the type of `elements?: [] | null` accepts an empty array, or null, while we want to accept any array (or null), so it should have been `any[] | null`. I've used `any[]` here since the types of the helper methods on elements (`setElements` and `getElements`) also accept `any[]` as types.