### PR TITLE
Content-Security-Policy Fixes

### DIFF
--- a/src/js/core/touch-navigation.js
+++ b/src/js/core/touch-navigation.js
@@ -227,7 +227,7 @@ export default function touchNavigation(instance) {
                 lastZoomedPosX = null;
                 zoomedPosX = null;
                 zoomedPosY = null;
-                mediaImage.setAttribute('style', '');
+                mediaImage.style = '';
                 return;
             }
             if (scale > maxScale) {

--- a/src/js/core/zoom.js
+++ b/src/js/core/zoom.js
@@ -71,8 +71,8 @@ export default class ZoomImages {
         this.zoomedIn = true;
     }
     zoomOut() {
-        this.img.parentNode.setAttribute('style', '');
-        this.img.setAttribute('style', this.img.getAttribute('data-style'));
+        this.img.parentNode.style = '';
+        this.img.style = this.img.getAttribute('data-style') ? this.img.getAttribute('data-style') : '';
         this.slide.classList.remove('zoomed');
         this.zoomedIn = false;
         this.currentX = null;

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -189,12 +189,8 @@ class GlightboxInit {
 
         const scrollBar = window.innerWidth - document.documentElement.clientWidth;
         if (scrollBar > 0) {
-            var styleSheet = document.createElement('style');
-            styleSheet.type = 'text/css';
-            styleSheet.className = 'gcss-styles';
-            styleSheet.innerText = `.gscrollbar-fixer {margin-right: ${scrollBar}px}`;
-            document.head.appendChild(styleSheet);
-            _.addClass(body, 'gscrollbar-fixer');
+            document.body.style.marginRight = `${scrollBar}px`;
+            _.addClass(body, 'gscrollbar-fixer'); // backwards compatibility
         }
 
         _.addClass(body, 'glightbox-open');
@@ -1247,6 +1243,7 @@ class GlightboxInit {
             const body = document.body;
             _.removeClass(html, 'glightbox-open');
             _.removeClass(body, 'glightbox-open touching gdesc-open glightbox-touch glightbox-mobile gscrollbar-fixer');
+            document.body.style.marginRight = '';
             this.modal.parentNode.removeChild(this.modal);
 
             this.trigger('close');

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1093,8 +1093,8 @@ class GlightboxInit {
                     maxHeightValue = slideTriggerNode.getAttribute('data-height') ?? maxHeightValue;
                 }
 
-                imgNode.setAttribute('style', `max-height: calc(${maxHeightValue} - ${descHeight}px)`);
-                description.setAttribute('style', `max-width: ${imgNode.offsetWidth}px;`);
+                imgNode.style = 'max-height: calc('.concat(maxHeightValue, ' - ').concat(descHeight, 'px)');
+                description.style = 'max-width: '.concat(imgNode.offsetWidth, 'px;');
             }
         }
 

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1142,15 +1142,15 @@ class GlightboxInit {
                 let vheight = video.offsetHeight;
                 let ratio = winHeight / vheight;
                 let vsize = { width: vwidth * ratio, height: vheight * ratio };
-                video.parentNode.setAttribute('style', `max-width: ${vsize.width}px`);
+                video.parentNode.style = 'max-width: '.concat(vsize.width, 'px');
 
                 if (descriptionResize) {
-                    description.setAttribute('style', `max-width: ${vsize.width}px;`);
+                    description.style = 'max-width: '.concat(vsize.width, 'px;');
                 }
             } else {
                 video.parentNode.style.maxWidth = `${videoWidth}`;
                 if (descriptionResize) {
-                    description.setAttribute('style', `max-width: ${videoWidth};`);
+                    description.style = 'max-width: '.concat(videoWidth, ';');
                 }
             }
         }

--- a/src/js/glightbox.js
+++ b/src/js/glightbox.js
@@ -1253,10 +1253,6 @@ class GlightboxInit {
                 this.settings.onClose();
             }
 
-            const styles = document.querySelector('.gcss-styles');
-            if (styles) {
-                styles.parentNode.removeChild(styles);
-            }
             this.lightboxOpen = false;
             this.closing = null;
         });

--- a/src/js/slides/video.js
+++ b/src/js/slides/video.js
@@ -99,7 +99,7 @@ export default function slideVideo(slide, data, index, callback) {
         );
         player.on('enterfullscreen', handleMediaFullScreen);
         player.on('exitfullscreen', handleMediaFullScreen);
-    }
+    };
 
     if (typeof this.settings.plyr.js === 'function') {
         this.settings.plyr.js().then(v => initPlyr(v.Plyr, v.config));

--- a/src/js/slides/video.js
+++ b/src/js/slides/video.js
@@ -46,23 +46,33 @@ export default function slideVideo(slide, data, index, callback) {
         // if no provider, default to local
         if (provider === 'local' || !provider) {
             provider = 'local';
-            let html = '<video id="' + videoID + '" ';
-            html += `style="background:#000; max-width: ${data.width};" `;
-            html += 'preload="metadata" ';
-            html += 'x-webkit-airplay="allow" ';
-            html += 'playsinline ';
-            html += 'controls ';
-            html += 'class="gvideo-local">';
-            html += `<source src="${url}">`;
-            html += '</video>';
-            customPlaceholder = createHTML(html);
+
+            const video = document.createElement('video');
+            video.id = videoID;
+            video.className = 'gvideo-local';
+            video.preload = 'metadata';
+            video.playsInline = true;
+            video.controls = true;
+            video.style.background = '#000';
+            video.style.maxWidth = data.width;
+            video.setAttribute('x-webkit-airplay', 'allow');
+
+            const source = document.createElement('source');
+            source.src = url;
+            video.appendChild(source);
+
+            customPlaceholder = video;
         }
 
-        // prettier-ignore
-        const placeholder = customPlaceholder ? customPlaceholder : createHTML(`<div id="${videoID}" data-plyr-provider="${provider}" data-plyr-embed-id="${url}"></div>`);
+        if (!customPlaceholder) {
+            customPlaceholder = document.createElement('div');
+            customPlaceholder.id = videoID;
+            customPlaceholder.dataset.plyrProvider = provider;
+            customPlaceholder.dataset.plyrEmbedId = url;
+        }
 
         addClass(videoWrapper, `${provider}-video gvideo`);
-        videoWrapper.appendChild(placeholder);
+        videoWrapper.appendChild(customPlaceholder);
         videoWrapper.setAttribute('data-id', videoID);
         videoWrapper.setAttribute('data-index', index);
 

--- a/src/js/slides/video.js
+++ b/src/js/slides/video.js
@@ -20,7 +20,11 @@ export default function slideVideo(slide, data, index, callback) {
 
     const videoWrapper = slide.querySelector('.gvideo-wrapper');
 
-    injectAssets(this.settings.plyr.css, 'Plyr');
+    if (typeof this.settings.plyr.css === 'function') {
+        this.settings.plyr.css();
+    } else {
+        injectAssets(this.settings.plyr.css, 'Plyr');
+    }
 
     let url = data.href;
     let provider = data?.videoProvider;
@@ -28,7 +32,7 @@ export default function slideVideo(slide, data, index, callback) {
 
     slideMedia.style.maxWidth = data.width;
 
-    injectAssets(this.settings.plyr.js, 'Plyr', () => {
+    const initPlyr = (Plyr, config) => {
         // Set vimeo videos
         if (!provider && url.match(/vimeo\.com\/([0-9]*)/)) {
             provider = 'vimeo';
@@ -76,7 +80,7 @@ export default function slideVideo(slide, data, index, callback) {
         videoWrapper.setAttribute('data-id', videoID);
         videoWrapper.setAttribute('data-index', index);
 
-        const playerConfig = has(this.settings.plyr, 'config') ? this.settings.plyr.config : {};
+        const playerConfig = config || (has(this.settings.plyr, 'config') ? this.settings.plyr.config : {});
         const player = new Plyr('#' + videoID, playerConfig);
 
         player.on('ready', (event) => {
@@ -95,7 +99,13 @@ export default function slideVideo(slide, data, index, callback) {
         );
         player.on('enterfullscreen', handleMediaFullScreen);
         player.on('exitfullscreen', handleMediaFullScreen);
-    });
+    }
+
+    if (typeof this.settings.plyr.js === 'function') {
+        this.settings.plyr.js().then(v => initPlyr(v.Plyr, v.config));
+    } else {
+        injectAssets(this.settings.plyr.js, 'Plyr', () => initPlyr(window.Plyr));
+    }
 }
 
 /**


### PR DESCRIPTION
For Image, Zoom, Touch-Navigation, Video, gscrollbar-fixer, Plyr

- set inline style using style element , not setAttribute (see #579)
- Do not use inline HTML to create the video placeholder elements, from pr #468
- Fix the CSP problem with .gscrollbar-fixer, from pr #468
- Plyr fixes from pr #468

(Thanks [qzminski](https://github.com/biati-digital/glightbox/issues?q=is%3Apr+author%3Aqzminski))